### PR TITLE
Fix monthly pay calculation

### DIFF
--- a/app/(tabs)/two.tsx
+++ b/app/(tabs)/two.tsx
@@ -2,11 +2,17 @@ import { StyleSheet } from 'react-native';
 
 import EditScreenInfo from '@/components/EditScreenInfo';
 import { Text, View } from '@/components/Themed';
+import { calculateGrossMonthlyPay } from '@/utils/calculateGrossMonthlyPay';
 
 export default function TabTwoScreen() {
+  const annualPay = 60000;
+  const monthlyPay = calculateGrossMonthlyPay(annualPay);
+
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>Tab Two</Text>
+      <Text style={styles.title}>Monthly Pay</Text>
+      <Text>Annual Pay: ${annualPay}</Text>
+      <Text>Gross Monthly Pay: ${monthlyPay.toFixed(2)}</Text>
       <View style={styles.separator} lightColor="#eee" darkColor="rgba(255,255,255,0.1)" />
       <EditScreenInfo path="app/(tabs)/two.tsx" />
     </View>

--- a/components/__tests__/__snapshots__/StyledText-test.js.snap
+++ b/components/__tests__/__snapshots__/StyledText-test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `null`;

--- a/utils/__tests__/calculateGrossMonthlyPay.test.ts
+++ b/utils/__tests__/calculateGrossMonthlyPay.test.ts
@@ -1,0 +1,5 @@
+import { calculateGrossMonthlyPay } from '../calculateGrossMonthlyPay';
+
+test('calculates monthly pay by dividing annual pay by 12', () => {
+  expect(calculateGrossMonthlyPay(120000)).toBe(10000);
+});

--- a/utils/calculateGrossMonthlyPay.ts
+++ b/utils/calculateGrossMonthlyPay.ts
@@ -1,0 +1,3 @@
+export function calculateGrossMonthlyPay(totalAnnualPay: number): number {
+  return totalAnnualPay / 12;
+}


### PR DESCRIPTION
## Summary
- add `calculateGrossMonthlyPay` utility
- use the utility in Tab Two screen
- test the monthly pay calculation
- update snapshot after running tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6886c0c1b8f48327bdd39f1dd9d97655